### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+bin/
+build/
+test.*
+*.png
+.vscode/


### PR DESCRIPTION
I noticed that the `node-audio` package on NPM has a few unnecessary files, including test.wav which is pretty big.

This PR may not be needed if you could remove them locally before publishing next version.

For reference, I checked: https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package

`.npmignore` ignores `.DS_Store` and `node_modules` by default. 