### PR TITLE
NodeAudio.cleanupAudioContext(), PluginNode instance .shutdown()

### DIFF
--- a/src/NodeAudio.cc
+++ b/src/NodeAudio.cc
@@ -8,11 +8,11 @@ using namespace lab;
 
 namespace NodeAudio {
   class NodeAudio {
-  public: 
+  public:
     static std::shared_ptr<lab::AudioContext> MakeAudioContext() {
       return lab::MakeAudioContext();
     }
-    
+
     static std::shared_ptr<lab::AudioHardwareSourceNode> MakeHardwareSourceNode(std::shared_ptr<lab::AudioContext> context) {
       std::shared_ptr<AudioHardwareSourceNode> input;
       {
@@ -22,10 +22,14 @@ namespace NodeAudio {
         }
       return input;
     }
+    static void CleanupAudioContext(std::shared_ptr<lab::AudioContext> context) {
+      return lab::CleanupAudioContext(context);
+    }
   };
 
   NBIND_CLASS(NodeAudio) {
     method(MakeAudioContext, "makeAudioContext");
     method(MakeHardwareSourceNode, "makeHardwareSourceNode");
+    method(CleanupAudioContext, "cleanupAudioContext");
   };
 }

--- a/src/extended/PluginHostChildProcess/main.cc
+++ b/src/extended/PluginHostChildProcess/main.cc
@@ -142,6 +142,10 @@ public:
       addToDesktop();
     }
 
+    void shutdown() override {
+      JUCEApplication::getInstance()->systemRequestedQuit();
+    }
+
     void closeButtonPressed() override {
       // This is called when the user tries to close this window. Here, we'll
       // just

--- a/src/extended/PluginNode.cc
+++ b/src/extended/PluginNode.cc
@@ -74,3 +74,6 @@ void PluginNode::displayGUI() {
 void PluginNode::hideGUI() {
   interface.hideGUI();
 }
+void PluginNode::shutdown() {
+  interface.shutdown();
+}

--- a/src/extended/PluginNode.h
+++ b/src/extended/PluginNode.h
@@ -15,19 +15,20 @@
 namespace NodeAudio {
   class PluginNode: public lab::AudioNode {
 
-  public: 
+  public:
     PluginNode(std::string _pluginPath, float sampleRate);
     void displayGUI();
     void hideGUI();
+    void shutdown();
     virtual ~PluginNode();
 
   private:
     virtual void process(lab::ContextRenderLock &, size_t framesToProcess) override;
     virtual void reset(lab::ContextRenderLock &) override;
-    
+
     virtual void initialize() override;
     virtual void uninitialize() override;
-    
+
     virtual double tailTime() const override { return 0; }
     virtual double latencyTime() const override { return 0; }
 

--- a/src/extended/Shared/PluginInterface.cc
+++ b/src/extended/Shared/PluginInterface.cc
@@ -4,6 +4,7 @@ using namespace NodeAudio;
 
 juce::String DISPLAY_GUI_ACTION = "DISPLAY_GUI";
 juce::String HIDE_GUI_ACTION = "HIDE_GUI";
+juce::String SHUTDOWN_ACTION = "SHUTDOWN";
 
 void PluginInterface::displayGUI() {
   juce::MemoryBlock block(DISPLAY_GUI_ACTION.toUTF8(), DISPLAY_GUI_ACTION.length());
@@ -15,13 +16,14 @@ void PluginInterface::hideGUI() {
   sendMessage(block);
 }
 
+void PluginInterface::shutdown() {
+  juce::MemoryBlock block(SHUTDOWN_ACTION.toUTF8(), SHUTDOWN_ACTION.length());
+  sendMessage(block);
+}
+
 void PluginInterfaceHost::messageReceived(const juce::MemoryBlock &message) {
   juce::String action = message.toString();
-  if(action == DISPLAY_GUI_ACTION) {
-    displayGUI();
-  }
-
-  if(action == HIDE_GUI_ACTION) {
-    hideGUI();
-  }
+  if (action == DISPLAY_GUI_ACTION) displayGUI();
+  else if (action == HIDE_GUI_ACTION) hideGUI();
+  else if (action == SHUTDOWN_ACTION) shutdown();
 }

--- a/src/extended/Shared/PluginInterface.h
+++ b/src/extended/Shared/PluginInterface.h
@@ -12,6 +12,7 @@ namespace NodeAudio {
 
     void displayGUI();
     void hideGUI();
+    void shutdown();
 
     void connectionMade() override {}
     void connectionLost() override {}
@@ -33,6 +34,7 @@ namespace NodeAudio {
 
     virtual void displayGUI() = 0;
     virtual void hideGUI() = 0;
+    virtual void shutdown() = 0;
   private:
     const std::string& pipeName;
     int receiveMessageTimeoutMs = 200;

--- a/src/module.cc
+++ b/src/module.cc
@@ -79,4 +79,5 @@ NBIND_CLASS(PluginNode) {
   inherit(AudioNode);
   method(displayGUI);
   method(hideGUI);
+  method(shutdown);
 }


### PR DESCRIPTION
I'm working on an Electron application that bundles `node-audio` for hosting VST/AudioUnit plugins. During development, `libc++abi.dylib` was throwing a mysterious error on app exit. The solution was to bind these clean-up methods, to be able to exit the application "cleanly" by shutting down any plugin instance, disconnecting all nodes, and cleaning up the audio context.